### PR TITLE
Bits and pieces

### DIFF
--- a/wp-content/themes/mozfest2012/front-page.php
+++ b/wp-content/themes/mozfest2012/front-page.php
@@ -2,13 +2,8 @@
 
 get_header();
 
-if (function_exists('get_custom_header')) {
-	$header = get_custom_header();
-	$header_text = get_post($header->attachment_id)->post_title;
-	$header_color = get_header_textcolor();
-	if (!empty($header_text) && $header_color !== 'blank') {
-		echo '<div id="carousel"><div class="constrained"></div></div>'."\n";
-	}
+if (get_header_image()) {
+	echo '<div id="carousel"><div class="constrained"></div></div>'."\n";
 }
 
 ?>

--- a/wp-content/themes/mozfest2012/functions.php
+++ b/wp-content/themes/mozfest2012/functions.php
@@ -240,15 +240,45 @@ function __mf2012_autolink_callback ($matches) {
 	if ($open == '[' && $close == ']') {
 		$label = trim($before) . trim($after);
 	} else {
-		if (preg_match('/\.(jpg|png|gif)$/', $link)) {
-			return '<img src="'.$link.'" style="max-width: 100%;">';
-		} else {
-			$label = preg_replace('|^https?://|', '', $link);
-			$label = preg_replace('|/$|', '', $label);
-		}
+		$label = preg_replace('|^https?://|', '', $link);
+		$label = preg_replace('|/$|', '', $label);
 	}
 
-	return '<a href="'.$link.'">'.$label.'</a>';
+	preg_match('/^(.*?)(\{.+\})(.*?)$/', $label, $meta);
+	if ($meta) {
+		$label = $meta[1] . $meta[2];
+		$meta = $meta[2];
+	} else {
+		$meta = '{}';
+	}
+
+	$meta = @json_decode($meta);
+	$attributes = array();
+
+	foreach ((object) $meta as $key => $value) {
+		if (is_array($value)) {
+			$value = implode(', ', $value);
+		} else if (is_object($value)) {
+			$attr = array();
+			foreach ($value as $k => $v) {
+				$attr[] = $k . ': ' . $v . ';';
+			}
+			$value = implode(' ', $attr);
+		}
+		$attributes[$key] = $value;
+	}
+
+	$attrs = array();
+	foreach ($attributes as $attribute => $value) {
+		$attrs[] = ' ' . $attribute . '="' . $value . '"';
+	}
+	$attrs = implode($attrs);
+
+	if (preg_match('/\.(jpg|png|gif)$/', $link)) {
+		return '<img src="'.$link.'"'.$attrs.'>';
+	} else {
+		return '<a href="'.$link.'"'.$attrs.'>'.$label.'</a>';
+	}
 }
 
 function mf2012_autolink ($str) {

--- a/wp-content/themes/mozfest2012/functions.php
+++ b/wp-content/themes/mozfest2012/functions.php
@@ -471,6 +471,15 @@ function mf2012_update_user ($user_id) {
 		} catch (Exception $e) {
 			// Ignore
 		}
+
+		$bio = $_REQUEST['description'];
+		if (empty($bio)) {
+			$info = @json_decode(file_get_contents('https://api.twitter.com/1/users/show.json?screen_name='.$_REQUEST['twitter']));
+			if (!empty($info)) {
+				$_POST['description'] = $info->description;
+				$_REQUEST['description'] = $info->description;
+			}
+		}
 	}
 
  	if (!is_null($avatar)) {

--- a/wp-content/themes/mozfest2012/functions.php
+++ b/wp-content/themes/mozfest2012/functions.php
@@ -487,6 +487,13 @@ function mf2012_update_user ($user_id) {
 	} else {
 		delete_user_meta($user_id, 'avatar');
 	}
+
+	if ($organizer_id = get_user_meta($user_id, 'organizer_id', true)) {
+		wp_update_term($organizer_id, 'organizer', array(
+			'name' => $_REQUEST['display_name'],
+			'description' => $_REQUEST['description'],
+		));
+	}
 }
 
 add_action('edit_user_profile_update', 'mf2012_update_user');


### PR DESCRIPTION
- Making session-related content descriptions hackable
- Fixing front page banner image problems
- Using Twitter bio for organisers, if none given
- Ensuring that organiser profiles are updated when corresponding user account is changed
